### PR TITLE
Refat-memberXproject

### DIFF
--- a/src/modules/create_action/app/create_action_controller.py
+++ b/src/modules/create_action/app/create_action_controller.py
@@ -1,4 +1,5 @@
 from src.shared.domain.entities.action import Action
+from src.shared.domain.entities.member import Member
 from src.shared.domain.enums.action_type_enum import ACTION_TYPE
 from src.shared.domain.enums.stack_enum import STACK
 from src.shared.helpers.errors.controller_errors import MissingParameters
@@ -61,6 +62,14 @@ class CreateActionController:
                 action_type_tag = ACTION_TYPE[action_type_tag_str]
             else:
                 action_type_tag = None
+                
+            if not Member.validate_ra(request.data.get('owner_ra')):
+                raise EntityError('owner_ra')
+            
+            if request.data.get('associated_members_ra') is not None:
+                for ra in request.data.get('associated_members_ra'):
+                    if not Member.validate_ra(ra):
+                        raise EntityError('associated_members_ra')
 
                    
             action = self.usecase(

--- a/src/modules/create_action/app/create_action_controller.py
+++ b/src/modules/create_action/app/create_action_controller.py
@@ -67,6 +67,8 @@ class CreateActionController:
                 raise EntityError('owner_ra')
             
             if request.data.get('associated_members_ra') is not None:
+                if type(request.data.get('associated_members_ra')) is not list:
+                    raise EntityError('associated_members_ra')
                 for ra in request.data.get('associated_members_ra'):
                     if not Member.validate_ra(ra):
                         raise EntityError('associated_members_ra')

--- a/src/modules/create_action/app/create_action_usecase.py
+++ b/src/modules/create_action/app/create_action_usecase.py
@@ -15,6 +15,10 @@ class CreateActionUsecase:
         
         action_id = str(uuid.uuid4())
         
+        for ra in [owner_ra] + associated_members_ra:
+            if not self.repo.get_member(ra):
+                raise NoItemsFound(ra)
+        
         action = Action(owner_ra, start_date, stack_tags, end_date, duration, action_id, title, project_code, action_type_tag, associated_members_ra, description, story_id)        
         
         self.repo.create_action(action)

--- a/src/modules/create_project/app/create_project_controller.py
+++ b/src/modules/create_project/app/create_project_controller.py
@@ -27,6 +27,8 @@ class CreateProjectController:
                 raise MissingParameters('scrum_RA')
             if request.data.get('start_date') is None:
                 raise MissingParameters('start_date')
+            if request.data.get('members') is None:
+                raise MissingParameters('members')
             if request.data.get('photos') is not None:
                 if type(request.data.get('photos')) is not list:
                     raise EntityError('photos')
@@ -41,6 +43,7 @@ class CreateProjectController:
                 po_RA=request.data.get('po_RA'),
                 scrum_RA=request.data.get('scrum_RA'),
                 start_date=request.data.get('start_date'),
+                members=request.data.get('members'),
                 photos=request.data.get('photos')
             )
             

--- a/src/modules/create_project/app/create_project_usecase.py
+++ b/src/modules/create_project/app/create_project_usecase.py
@@ -1,3 +1,4 @@
+from typing import List
 from src.shared.domain.entities.project import Project
 from src.shared.domain.repositories.action_repository_interface import IActionRepository
 from src.shared.helpers.errors.domain_errors import EntityError
@@ -7,7 +8,7 @@ class CreateProjectUsecase:
     def __init__(self, repo: IActionRepository):
         self.repo = repo
         
-    def __call__(self, code: str, name: str, description: str, po_RA: str, scrum_RA: str, start_date: int, photos: list = None) -> Project:
+    def __call__(self, code: str, name: str, description: str, po_RA: str, scrum_RA: str, start_date: int, members: List[str], photos: list = None) -> Project:
         
         # if self.repo.get_project(project_id=project.project_id) is not None:
         #     raise DuplicatedItem('project_id')
@@ -19,7 +20,8 @@ class CreateProjectUsecase:
             po_RA=po_RA,
             scrum_RA=scrum_RA,
             start_date=start_date,
-            photos=photos
+            photos=photos,
+            members=members
         )
         
         return self.repo.create_project(project)

--- a/src/modules/create_project/app/create_project_viewmodel.py
+++ b/src/modules/create_project/app/create_project_viewmodel.py
@@ -8,6 +8,7 @@ class ProjectViewModel:
     po_RA: str
     scrum_RA: str
     start_date: int
+    members: List[str]
     photos: List[str] = None
     
     def __init__(self, project: Project):
@@ -17,6 +18,7 @@ class ProjectViewModel:
         self.po_RA = project.po_RA
         self.scrum_RA = project.scrum_RA
         self.start_date = project.start_date
+        self.members = project.members
         self.photos = project.photos if project.photos else []
         
     def to_dict(self):
@@ -27,6 +29,7 @@ class ProjectViewModel:
             'po_RA' : self.po_RA,
             'scrum_RA' : self.scrum_RA,
             'start_date' : self.start_date,
+            'members' : self.members,
             'photos' : self.photos
         }
 

--- a/src/modules/delete_project/app/delete_project_viewmodel.py
+++ b/src/modules/delete_project/app/delete_project_viewmodel.py
@@ -8,6 +8,7 @@ class ProjectViewModel:
     po_RA: str
     scrum_RA: str
     start_date: int
+    members: List[str]
     photos: List[str]
 
     def __init__(self, project: Project):
@@ -17,6 +18,7 @@ class ProjectViewModel:
         self.po_RA = project.po_RA
         self.scrum_RA = project.scrum_RA
         self.start_date = project.start_date
+        self.members = project.members
         self.photos = project.photos
 
     def to_dict(self):
@@ -27,6 +29,7 @@ class ProjectViewModel:
             'po_RA' : self.po_RA,
             'scrum_RA' : self.scrum_RA,
             'start_date' : self.start_date,
+            'members' : self.members,
             'photos' : self.photos
         }
 

--- a/src/modules/get_all_projects/app/get_all_projects_controller.py
+++ b/src/modules/get_all_projects/app/get_all_projects_controller.py
@@ -10,8 +10,8 @@ class GetAllProjectsController:
     
     def __call__(self, request: IRequest) -> IResponse:
         try:
-            projects_members = self.usecase()
-            viewmodel = GetAllProjectsViewmodel(projects_members)
+            projects = self.usecase()
+            viewmodel = GetAllProjectsViewmodel(projects)
             return OK(viewmodel.to_dict())
         
         except Exception as err:

--- a/src/modules/get_all_projects/app/get_all_projects_usecase.py
+++ b/src/modules/get_all_projects/app/get_all_projects_usecase.py
@@ -7,14 +7,5 @@ class GetAllProjectsUsecase:
         
     def __call__(self):
         projects = self.repo.get_all_projects()
-        # members = self.repo.get_all_members()
-        
-        # projects_with_members = []
-        # for project in projects:
-        #     members_in_project = []
-        #     for member in members:
-        #         if project.code in member.projects:
-        #             members_in_project.append(member)
-        #     projects_with_members.append((project, members_in_project))
     
         return projects

--- a/src/modules/get_all_projects/app/get_all_projects_usecase.py
+++ b/src/modules/get_all_projects/app/get_all_projects_usecase.py
@@ -7,14 +7,14 @@ class GetAllProjectsUsecase:
         
     def __call__(self):
         projects = self.repo.get_all_projects()
-        members = self.repo.get_all_members()
+        # members = self.repo.get_all_members()
         
-        projects_with_members = []
-        for project in projects:
-            members_in_project = []
-            for member in members:
-                if project.code in member.projects:
-                    members_in_project.append(member)
-            projects_with_members.append((project, members_in_project))
+        # projects_with_members = []
+        # for project in projects:
+        #     members_in_project = []
+        #     for member in members:
+        #         if project.code in member.projects:
+        #             members_in_project.append(member)
+        #     projects_with_members.append((project, members_in_project))
     
-        return projects_with_members
+        return projects

--- a/src/modules/get_all_projects/app/get_all_projects_viewmodel.py
+++ b/src/modules/get_all_projects/app/get_all_projects_viewmodel.py
@@ -32,75 +32,25 @@ class ProjectViewModel:
             'photos' : self.photos
         }
         
-class MemberViewModel:
-    name: str
-    email_dev: str
-    email: str
-    ra: str
-    role: str
-    stack: str
-    year: int
-    cellphone: str
-    course: str
-    hired_date: int
-    deactivated_date: Optional[int] = None
-    active: str
-    projects: List[str]
-    
-    def __init__(self, member: Member):
-        self.name = member.name
-        self.email_dev = member.email_dev
-        self.email = member.email
-        self.ra = member.ra
-        self.role = member.role.value
-        self.stack = member.stack.value
-        self.year = member.year
-        self.cellphone = member.cellphone
-        self.course = member.course.value
-        self.hired_date = member.hired_date
-        self.deactivated_date = member.deactivated_date
-        self.active = member.active.value
-        self.projects = member.projects
-        
-    def to_dict(self):
-        return {
-            'name' : self.name,
-            'email_dev' : self.email_dev,
-            'email' : self.email,
-            'ra' : self.ra,
-            'role' : self.role,
-            'stack' : self.stack,
-            'year' : self.year,
-            'cellphone' : self.cellphone,
-            'course' : self.course,
-            'hired_date' : self.hired_date,
-            'deactivated_date' : self.deactivated_date,
-            'active' : self.active,
-            'projects' : self.projects
-        }
-
 class GetProjectViewmodel:
     project: ProjectViewModel
-    members: List[MemberViewModel]
     
-    def __init__(self, project: Project, members: List[Member]):
+    def __init__(self, project: Project):
         self.project = ProjectViewModel(project)
-        self.members = [MemberViewModel(member) for member in members]
         
     def to_dict(self):
         return {
-            'project' : self.project.to_dict(),
-            'members' : [member.to_dict() for member in self.members]
+            'project' : self.project.to_dict()
         }
 
 class GetAllProjectsViewmodel:
-    projects_members: List[GetProjectViewmodel]
+    projects: List[GetProjectViewmodel]
     
-    def __init__(self, projects_members: List[Tuple[Project, List[Member]]]):	
-        self.projects_members = [GetProjectViewmodel(project, members) for project, members in projects_members]
+    def __init__(self, projects: List[Tuple[Project]]):	
+        self.projects = [GetProjectViewmodel(project) for project in projects]
         
     def to_dict(self):
         return {
-            'projects' : [project_member.to_dict() for project_member in self.projects_members],
+            'projects' : [project.to_dict() for project in self.projects],
             'message' : 'the projects were retrieved'
         }

--- a/src/modules/get_member/app/get_member_viewmodel.py
+++ b/src/modules/get_member/app/get_member_viewmodel.py
@@ -18,7 +18,6 @@ class GetMemberViewModel:
     hired_date: int
     deactivated_date: Optional[int] = None
     active: ACTIVE
-    projects: Optional[List[str]] = None
 
     def __init__(self, member: Member):
         self.name = member.name
@@ -33,7 +32,6 @@ class GetMemberViewModel:
         self.hired_date = member.hired_date
         self.deactivated_date = member.deactivated_date
         self.active = member.active
-        self.projects = member.projects
 
     def to_dict(self):
         return {
@@ -49,8 +47,7 @@ class GetMemberViewModel:
                 'course' : self.course.value,
                 'hired_date' : self.hired_date,
                 'deactivated_date' : self.deactivated_date,
-                'active' : self.active.value,
-                'projects' : self.projects
+                'active' : self.active.value
             },
             "message" : "the member was retrieved"
         }

--- a/src/modules/get_project/app/get_project_controller.py
+++ b/src/modules/get_project/app/get_project_controller.py
@@ -19,8 +19,8 @@ class GetProjectController:
             if request.data.get('code') is None:
                 raise MissingParameters('code')
             
-            project, members = self.usecase(request.data.get('code'))
-            viewmodel = GetProjectViewmodel(project=project, members=members)
+            project= self.usecase(request.data.get('code'))
+            viewmodel = GetProjectViewmodel(project=project)
             return OK(viewmodel.to_dict())
         
         except MissingParameters as err:

--- a/src/modules/get_project/app/get_project_usecase.py
+++ b/src/modules/get_project/app/get_project_usecase.py
@@ -21,6 +21,6 @@ class GetProjectUsecase:
         if project is None:
             raise NoItemsFound('code')
         
-        tup = project, self.repo.get_members_by_project(code=code)
+        tup = project
         
         return tup

--- a/src/modules/get_project/app/get_project_viewmodel.py
+++ b/src/modules/get_project/app/get_project_viewmodel.py
@@ -31,50 +31,6 @@ class ProjectViewModel:
             'start_date' : self.start_date,
             'photos' : self.photos
         }
-        
-# class MemberViewModel:
-#     name: str
-#     email_dev: str
-#     email: str
-#     ra: str
-#     role: str
-#     stack: str
-#     year: int
-#     cellphone: str
-#     course: str
-#     hired_date: int
-#     deactivated_date: Optional[int] = None
-#     active: str
-    
-#     def __init__(self, member: Member):
-#         self.name = member.name
-#         self.email_dev = member.email_dev
-#         self.email = member.email
-#         self.ra = member.ra
-#         self.role = member.role.value
-#         self.stack = member.stack.value
-#         self.year = member.year
-#         self.cellphone = member.cellphone
-#         self.course = member.course.value
-#         self.hired_date = member.hired_date
-#         self.deactivated_date = member.deactivated_date
-#         self.active = member.active.value
-        
-#     def to_dict(self):
-#         return {
-#             'name' : self.name,
-#             'email_dev' : self.email_dev,
-#             'email' : self.email,
-#             'ra' : self.ra,
-#             'role' : self.role,
-#             'stack' : self.stack,
-#             'year' : self.year,
-#             'cellphone' : self.cellphone,
-#             'course' : self.course,
-#             'hired_date' : self.hired_date,
-#             'deactivated_date' : self.deactivated_date,
-#             'active' : self.active
-#         }
 
 class GetProjectViewmodel:
     project: ProjectViewModel
@@ -82,11 +38,9 @@ class GetProjectViewmodel:
     
     def __init__(self, project: Project):
         self.project = ProjectViewModel(project)
-        #self.members = [MemberViewModel(member) for member in members]
         
     def to_dict(self):
         return {
             'project' : self.project.to_dict(),
-            #'members' : [member.to_dict() for member in self.members],
             'message' : 'the project was retrieved'
         }

--- a/src/modules/get_project/app/get_project_viewmodel.py
+++ b/src/modules/get_project/app/get_project_viewmodel.py
@@ -32,64 +32,61 @@ class ProjectViewModel:
             'photos' : self.photos
         }
         
-class MemberViewModel:
-    name: str
-    email_dev: str
-    email: str
-    ra: str
-    role: str
-    stack: str
-    year: int
-    cellphone: str
-    course: str
-    hired_date: int
-    deactivated_date: Optional[int] = None
-    active: str
-    projects: List[str]
+# class MemberViewModel:
+#     name: str
+#     email_dev: str
+#     email: str
+#     ra: str
+#     role: str
+#     stack: str
+#     year: int
+#     cellphone: str
+#     course: str
+#     hired_date: int
+#     deactivated_date: Optional[int] = None
+#     active: str
     
-    def __init__(self, member: Member):
-        self.name = member.name
-        self.email_dev = member.email_dev
-        self.email = member.email
-        self.ra = member.ra
-        self.role = member.role.value
-        self.stack = member.stack.value
-        self.year = member.year
-        self.cellphone = member.cellphone
-        self.course = member.course.value
-        self.hired_date = member.hired_date
-        self.deactivated_date = member.deactivated_date
-        self.active = member.active.value
-        self.projects = member.projects
+#     def __init__(self, member: Member):
+#         self.name = member.name
+#         self.email_dev = member.email_dev
+#         self.email = member.email
+#         self.ra = member.ra
+#         self.role = member.role.value
+#         self.stack = member.stack.value
+#         self.year = member.year
+#         self.cellphone = member.cellphone
+#         self.course = member.course.value
+#         self.hired_date = member.hired_date
+#         self.deactivated_date = member.deactivated_date
+#         self.active = member.active.value
         
-    def to_dict(self):
-        return {
-            'name' : self.name,
-            'email_dev' : self.email_dev,
-            'email' : self.email,
-            'ra' : self.ra,
-            'role' : self.role,
-            'stack' : self.stack,
-            'year' : self.year,
-            'cellphone' : self.cellphone,
-            'course' : self.course,
-            'hired_date' : self.hired_date,
-            'deactivated_date' : self.deactivated_date,
-            'active' : self.active,
-            'projects' : self.projects
-        }
+#     def to_dict(self):
+#         return {
+#             'name' : self.name,
+#             'email_dev' : self.email_dev,
+#             'email' : self.email,
+#             'ra' : self.ra,
+#             'role' : self.role,
+#             'stack' : self.stack,
+#             'year' : self.year,
+#             'cellphone' : self.cellphone,
+#             'course' : self.course,
+#             'hired_date' : self.hired_date,
+#             'deactivated_date' : self.deactivated_date,
+#             'active' : self.active
+#         }
 
 class GetProjectViewmodel:
     project: ProjectViewModel
-    members: List[MemberViewModel]
+    #members: List[MemberViewModel]
     
-    def __init__(self, project: Project, members: List[Member]):
+    def __init__(self, project: Project):
         self.project = ProjectViewModel(project)
-        self.members = [MemberViewModel(member) for member in members]
+        #self.members = [MemberViewModel(member) for member in members]
         
     def to_dict(self):
         return {
             'project' : self.project.to_dict(),
-            'members' : [member.to_dict() for member in self.members],
+            #'members' : [member.to_dict() for member in self.members],
             'message' : 'the project was retrieved'
         }

--- a/src/shared/domain/entities/member.py
+++ b/src/shared/domain/entities/member.py
@@ -39,8 +39,7 @@ class Member(abc.ABC):
                  course: COURSE,
                  hired_date: int, 
                  active: ACTIVE,
-                 deactivated_date: Optional[int] = None, 
-                 projects: Optional[List[str]] = None
+                 deactivated_date: Optional[int] = None
                 ):
 
         if not Member.validate_name(name):
@@ -90,18 +89,6 @@ class Member(abc.ABC):
         if type(active) != ACTIVE:
             raise EntityError("active")
         self.active = active
-        
-        if projects is None:
-            self.projects = []
-        elif type(projects) == list:
-            if not all([type(project) == str for project in projects]):
-                raise EntityError("projects")
-            elif not all([Member.validate_project_code(project) for project in projects]):
-                raise EntityError("projects")
-            else:
-                self.projects = projects
-        else:
-            raise EntityError("projects")
             
         if deactivated_date is not None:
             if type(deactivated_date) != int:
@@ -168,19 +155,6 @@ class Member(abc.ABC):
             return False
         
         if len(cellphone) != Member.CELLPHONE_LENGTH:
-            return False
-        
-        return True
-        
-    @staticmethod
-    def validate_project_code(code: str) -> bool:
-        if type(code) != str:
-            return False
-        
-        if len(code) != Project.PROJECT_CODE_LENGTH:
-            return False
-        
-        if not code.isupper() and not code.isalpha():
             return False
         
         return True

--- a/src/shared/domain/entities/project.py
+++ b/src/shared/domain/entities/project.py
@@ -56,7 +56,7 @@ class Project(abc.ABC):
             raise EntityError("members")
         if po_RA not in members or scrum_RA not in members:
             raise EntityError("members")
-        self.members = list(set(members))
+        self.members = sorted(list(set(members)))
         
     @staticmethod
     def validate_project_code(code: str) -> bool:

--- a/src/shared/domain/entities/project.py
+++ b/src/shared/domain/entities/project.py
@@ -83,16 +83,18 @@ class Project(abc.ABC):
     def change_po_RA(self, new_po_RA: str):
         if not self.validate_RA(new_po_RA):
             raise EntityError("po_RA")
-        if new_po_RA not in self.members:
-            raise EntityError("po_RA")
+        self.members.remove(self.po_RA)
         self.po_RA = new_po_RA
+        self.members.append(new_po_RA)
+        self.members = sorted(list(set(self.members)))
 
     def change_scrum_RA(self, new_scrum_RA: str):
         if not self.validate_RA(new_scrum_RA):
             raise EntityError("scrum_RA")
-        if new_scrum_RA not in self.members:
-            raise EntityError("scrum_RA")
+        self.members.remove(self.scrum_RA)
         self.scrum_RA = new_scrum_RA
+        self.members.append(new_scrum_RA)
+        self.members = sorted(list(set(self.members)))
     
     def __repr__(self):
         return f"Project(code={self.code}, name={self.name}, description={self.description})"

--- a/src/shared/domain/entities/project.py
+++ b/src/shared/domain/entities/project.py
@@ -10,10 +10,11 @@ class Project(abc.ABC):
     po_RA: str
     scrum_RA: str
     start_date: int # milliseconds
+    members: List[str]
     photos: List[str] = []
     PROJECT_CODE_LENGTH = 2
     
-    def __init__(self, code: str, name: str, description: str, po_RA: str, scrum_RA: str, start_date: int, photos: List[str] = []):
+    def __init__(self, code: str, name: str, description: str, po_RA: str, scrum_RA: str, start_date: int, members: List[str], photos: List[str] = []):
         if not self.validate_project_code(code):
             raise EntityError("code")
         self.code = code
@@ -47,6 +48,15 @@ class Project(abc.ABC):
                 raise EntityError("photos")
             self.photos = photos
         
+        if type(members) != list:
+            raise EntityError("members")
+        if len(members) < 1:
+            raise EntityError("members")
+        if not all([self.validate_RA(ra) for ra in members]):
+            raise EntityError("members")
+        if po_RA not in members or scrum_RA not in members:
+            raise EntityError("members")
+        self.members = list(set(members))
         
     @staticmethod
     def validate_project_code(code: str) -> bool:
@@ -69,6 +79,20 @@ class Project(abc.ABC):
         if not ra.isdecimal():
             return False
         return True
+    
+    def change_po_RA(self, new_po_RA: str):
+        if not self.validate_RA(new_po_RA):
+            raise EntityError("po_RA")
+        if new_po_RA not in self.members:
+            raise EntityError("po_RA")
+        self.po_RA = new_po_RA
+
+    def change_scrum_RA(self, new_scrum_RA: str):
+        if not self.validate_RA(new_scrum_RA):
+            raise EntityError("scrum_RA")
+        if new_scrum_RA not in self.members:
+            raise EntityError("scrum_RA")
+        self.scrum_RA = new_scrum_RA
     
     def __repr__(self):
         return f"Project(code={self.code}, name={self.name}, description={self.description})"

--- a/src/shared/domain/repositories/action_repository_interface.py
+++ b/src/shared/domain/repositories/action_repository_interface.py
@@ -47,14 +47,6 @@ class IActionRepository(ABC):
         pass
     
     @abstractmethod
-    def get_members_by_project(self, code: str) -> List[Member]:
-        '''
-        Returns all members associated to the project with the given code, if any
-        else returns []
-        '''
-        pass
-    
-    @abstractmethod
     def get_project(self, code: str) -> Project:
         '''
         If project exists, returns it

--- a/src/shared/infra/repositories/action_repository_mock.py
+++ b/src/shared/infra/repositories/action_repository_mock.py
@@ -554,9 +554,9 @@ class ActionRepositoryMock(IActionRepository):
                 if new_description is not None:
                     project.description = new_description
                 if new_po_RA is not None:
-                    project.po_RA = new_po_RA
+                    project.change_po_RA(new_po_RA)
                 if new_scrum_RA is not None:
-                    project.scrum_RA = new_scrum_RA
+                    project.change_scrum_RA(new_scrum_RA)
                 if new_photos is not None:
                     project.photos = new_photos
                 if new_members is not None:

--- a/src/shared/infra/repositories/action_repository_mock.py
+++ b/src/shared/infra/repositories/action_repository_mock.py
@@ -75,10 +75,7 @@ class ActionRepositoryMock(IActionRepository):
                 cellphone="11991758098",
                 course=COURSE.ECA,
                 hired_date=1634576165000,
-                active=ACTIVE.ACTIVE,
-                projects=[
-                    self.projects[0].code
-                ]
+                active=ACTIVE.ACTIVE
             ),
 
             Member(
@@ -92,12 +89,7 @@ class ActionRepositoryMock(IActionRepository):
                 cellphone="11991152348",
                 course=COURSE.ECM,
                 hired_date=1634921765000,
-                active=ACTIVE.ACTIVE,
-                projects=[
-                    self.projects[0].code,
-                    self.projects[1].code,
-                    self.projects[2].code
-                ]
+                active=ACTIVE.ACTIVE
             ),
 
             Member(
@@ -111,9 +103,7 @@ class ActionRepositoryMock(IActionRepository):
                 cellphone="11991758228",
                 course=COURSE.CIC,
                 hired_date=1640192165000,
-                active=ACTIVE.FREEZE,
-                projects=[
-                ]
+                active=ACTIVE.FREEZE
             ),
 
             Member(
@@ -127,15 +117,7 @@ class ActionRepositoryMock(IActionRepository):
                 cellphone="11991759998",
                 course=COURSE.ECM,
                 hired_date=1614567601000,
-                active=ACTIVE.ACTIVE,
-                projects=[
-                    self.projects[0].code,
-                    self.projects[1].code,
-                    self.projects[2].code,
-                    self.projects[3].code
-
-
-                ]
+                active=ACTIVE.ACTIVE
             ),
 
             Member(
@@ -149,10 +131,7 @@ class ActionRepositoryMock(IActionRepository):
                 cellphone="11991753208",
                 course=COURSE.EMC,
                 hired_date=1614567601000,
-                active=ACTIVE.DISCONNECTED,
-                projects=[
-                ],
-                deactivated_date=1646103601000
+                active=ACTIVE.DISCONNECTED
             ),
 
             Member(
@@ -166,11 +145,7 @@ class ActionRepositoryMock(IActionRepository):
                 cellphone="11911758098",
                 course=COURSE.ECM,
                 hired_date=1640192165000,
-                active=ACTIVE.ACTIVE,
-                projects=[
-                    self.projects[3].code,
-                    self.projects[2].code
-                ]
+                active=ACTIVE.ACTIVE
             ),
 
             Member(
@@ -184,9 +159,7 @@ class ActionRepositoryMock(IActionRepository):
                 cellphone="11915758098",
                 course=COURSE.ECA,
                 hired_date=1609606565000,
-                active=ACTIVE.FREEZE,
-                projects=[
-                ]
+                active=ACTIVE.FREEZE
             ),
 
             Member(
@@ -200,9 +173,7 @@ class ActionRepositoryMock(IActionRepository):
                 cellphone="11991123498",
                 course=COURSE.ECM,
                 hired_date=1672592165000,
-                active=ACTIVE.ACTIVE,
-                projects=[
-                ]
+                active=ACTIVE.ACTIVE
             )
         ]
 
@@ -563,14 +534,6 @@ class ActionRepositoryMock(IActionRepository):
             if self.projects[i].code == code:
                 return self.projects.pop(i)
         return None
-
-    def get_members_by_project(self, code: str) -> List[Member]:
-        members = []
-        for member in self.members:
-            for project_code in member.projects:
-                if project_code == code:
-                    members.append(member)
-        return members
 
     def get_project(self, code: str) -> Project:
         for project in self.projects:

--- a/src/shared/infra/repositories/action_repository_mock.py
+++ b/src/shared/infra/repositories/action_repository_mock.py
@@ -26,7 +26,8 @@ class ActionRepositoryMock(IActionRepository):
                 po_RA="21017310",
                 scrum_RA="21010757",
                 start_date=1634576165000,
-                photos=["https://i.imgur.com/gHoRKJU.png"]
+                photos=["https://i.imgur.com/gHoRKJU.png"],
+                members=["21017310", "21010757", "10017310"]
             ),
             Project(
                 code="PT",
@@ -35,7 +36,8 @@ class ActionRepositoryMock(IActionRepository):
                 po_RA="22011020",
                 scrum_RA="21010757",
                 start_date=1673535600000,
-                photos=["https://i.imgur.com/gHoRKJU.png"]
+                photos=["https://i.imgur.com/gHoRKJU.png"],
+                members=["22011020", "21010757", "10017310"]
             ),
             Project(
                 code="SF",
@@ -43,7 +45,8 @@ class ActionRepositoryMock(IActionRepository):
                 description="Aplicativo para reconhecimento facial",
                 po_RA="22931270",
                 scrum_RA="21020532",
-                start_date=1686754800000
+                start_date=1686754800000,
+                members=["22931270", "21020532", "21010757","19017311", "10017310"]
             ),
             Project(
                 code="SM",
@@ -51,7 +54,8 @@ class ActionRepositoryMock(IActionRepository):
                 description="Site do evento SMILE",
                 po_RA="15014025",
                 scrum_RA="21010757",
-                start_date=1639321200000
+                start_date=1639321200000,
+                members=["15014025", "21010757", "19017311", "10017310"]
             ),
             Project(
                 code="GM",
@@ -59,7 +63,8 @@ class ActionRepositoryMock(IActionRepository):
                 description="Projeto para organização dos membros do DEV",
                 po_RA="22084120",
                 scrum_RA="22015940",
-                start_date=1672585200000
+                start_date=1672585200000,
+                members=["22084120", "22015940"]
             )
         ]
 
@@ -541,7 +546,7 @@ class ActionRepositoryMock(IActionRepository):
                 return project
         return None
     
-    def update_project(self, code: str, new_name: str = None, new_description: str = None, new_po_RA: str = None, new_scrum_RA: str = None, new_photos: List[str] = None) -> Project:
+    def update_project(self, code: str, new_name: str = None, new_description: str = None, new_po_RA: str = None, new_scrum_RA: str = None, new_members: List[str] = None, new_photos: List[str] = None) -> Project:
         for project in self.projects:
             if project.code == code:
                 if new_name is not None:
@@ -554,6 +559,8 @@ class ActionRepositoryMock(IActionRepository):
                     project.scrum_RA = new_scrum_RA
                 if new_photos is not None:
                     project.photos = new_photos
+                if new_members is not None:
+                    project.members = new_members
 
                 return project
             

--- a/tests/modules/create_action/app/test_create_action_controller.py
+++ b/tests/modules/create_action/app/test_create_action_controller.py
@@ -487,3 +487,47 @@ class Test_CreateActionController:
             response = controller(request)
             assert response.status_code == 400
             assert response.body == 'Field story_id is not valid'
+            
+    def test_create_action_controller_invalid_owner_ra(self):
+            
+            repo = ActionRepositoryMock()
+            usecase = CreateActionUsecase(repo=repo)
+            controller = CreateActionController(usecase=usecase)
+            request = HttpRequest(body={
+                'owner_ra':'3 21 18 9 15 19 15',
+                'start_date':1634526000000,
+                'story_id': 100,
+                'title':'Teste',
+                'end_date' : 1634533200000,
+                'duration' : 7200000,
+                'project_code':'MF',
+                'associated_members_ra':['19017310'],
+                'stack_tags':['BACKEND'],
+                'action_type_tag':'CODE'
+            })
+            
+            response = controller(request)
+            assert response.status_code == 400
+            assert response.body == 'Field owner_ra is not valid'
+            
+    def test_create_action_controller_invalid_associated_ra(self):
+            
+            repo = ActionRepositoryMock()
+            usecase = CreateActionUsecase(repo=repo)
+            controller = CreateActionController(usecase=usecase)
+            request = HttpRequest(body={
+                'owner_ra':'17033730',
+                'start_date':1634526000000,
+                'story_id': 100,
+                'title':'Teste',
+                'end_date' : 1634533200000,
+                'duration' : 7200000,
+                'project_code':'MF',
+                'associated_members_ra':['3 21 18 9 15 19 15'],
+                'stack_tags':['BACKEND'],
+                'action_type_tag':'CODE'
+            })
+            
+            response = controller(request)
+            assert response.status_code == 400
+            assert response.body == 'Field associated_members_ra is not valid'

--- a/tests/modules/create_action/app/test_create_action_presenter.py
+++ b/tests/modules/create_action/app/test_create_action_presenter.py
@@ -186,3 +186,61 @@ class Test_CreateActionPresenter:
         
         assert response["statusCode"] == 400
         assert json.loads(response["body"]) == 'Field owner_ra is not valid'
+        
+    def test_create_action_presenter_no_items_found(self):
+        event = {
+            "version": "2.0",
+            "routeKey": "$default",
+            "rawPath": "/my/path",
+            "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+            "cookies": [
+                "cookie1",
+                "cookie2"
+            ],
+            "headers": {
+                "header1": "value1",
+                "header2": "value1,value2"
+            },
+            "queryStringParameters": {
+                "parameter1": "1"
+            },
+            "requestContext": {
+                "accountId": "123456789012",
+                "apiId": "<urlid>",
+                "authentication": None,
+                "authorizer": {
+                    "iam": {
+                        "accessKey": "AKIA...",
+                        "accountId": "111122223333",
+                        "callerId": "AIDA...",
+                        "cognitoIdentity": None,
+                        "principalOrgId": None,
+                        "userArn": "arn:aws:iam::111122223333:user/example-user",
+                        "userId": "AIDA..."
+                    }
+                },
+                "domainName": "<url-id>.lambda-url.us-west-2.on.aws",
+                "domainPrefix": "<url-id>",
+                "external_interfaces": {
+                    "method": "POST",
+                    "path": "/my/path",
+                    "protocol": "HTTP/1.1",
+                    "sourceIp": "123.123.123.123",
+                    "userAgent": "agent"
+                },
+                "requestId": "id",
+                "routeKey": "$default",
+                "stage": "$default",
+                "time": "12/Mar/2020:19:03:58 +0000",
+                "timeEpoch": 1583348638390
+            },
+            "body": '{"owner_ra":"12345678","start_date":1634526000000,"action_id":"82fc","title":"Teste","end_date":1634533200000, "duration":7200000, "project_code":"MF","associated_members_ra":["19017310"],"stack_tags":["BACKEND"],"action_type_tag":"CODE", "story_id":100}',
+            "pathParameters": None,
+            "isBase64Encoded": None,
+            "stageVariables": None
+        }
+        
+        response = lambda_handler(event, None)
+        
+        assert response["statusCode"] == 404
+        assert json.loads(response["body"]) == 'No items found for 12345678'

--- a/tests/modules/create_action/app/test_create_action_usecase.py
+++ b/tests/modules/create_action/app/test_create_action_usecase.py
@@ -39,3 +39,11 @@ class Test_CreateActionUsecase:
         action = usecase(owner_ra='17033730', start_date=1634526000000, duration=2*60*60*1000, story_id=100, associated_members_ra=[], title='Teste', end_date=1634536800000, project_code='MF', stack_tags=[STACK.BACKEND], action_type_tag=ACTION_TYPE.CODE)
         assert len(repo.actions) == lenActionBefore + 1
         assert repo.actions[-1] == action
+        
+    def test_create_action_usecase_ra_not_found(self):
+        repo = ActionRepositoryMock()
+        usecase = CreateActionUsecase(repo=repo)
+        lenActionBefore = len(repo.actions)
+        
+        with pytest.raises(NoItemsFound):
+            action = usecase(owner_ra='17033730', start_date=1634526000000, duration=2*60*60*1000, story_id=100, associated_members_ra=['21017310', '21010757', '21010758'], title='Teste', end_date=1634536800000, project_code='MF', stack_tags=[STACK.BACKEND], action_type_tag=ACTION_TYPE.CODE)

--- a/tests/modules/create_project/app/test_create_project_controller.py
+++ b/tests/modules/create_project/app/test_create_project_controller.py
@@ -17,6 +17,7 @@ class Test_CreateProjectController:
             'po_RA':'21021031',
             'scrum_RA':'17033730',
             'start_date':1649955600000,
+            'members':['17033730','21021031'],
             'photos':['https://i.imgur.com/7QF7uCk.png']
         })
         response = controller(request)
@@ -28,6 +29,7 @@ class Test_CreateProjectController:
         assert response.body['project']['po_RA'] == '21021031'
         assert response.body['project']['scrum_RA'] == '17033730'
         assert response.body['project']['start_date'] == 1649955600000
+        assert response.body['project']['members'] == ['17033730','21021031']
         assert response.body['project']['photos'] == ['https://i.imgur.com/7QF7uCk.png']
         
     def test_create_project_controller_missing_photos(self):
@@ -41,7 +43,8 @@ class Test_CreateProjectController:
             'description':'Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano',
             'po_RA':'21021031',
             'scrum_RA':'17033730',
-            'start_date':1649955600000
+            'start_date':1649955600000,
+            'members':['21021031', '17033730']
         })
         response = controller(request)
         assert response.status_code == 201
@@ -57,7 +60,8 @@ class Test_CreateProjectController:
             'description':'Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano',
             'po_RA':'21021031',
             'scrum_RA':'17033730',
-            'start_date':1649955600000
+            'start_date':1649955600000,
+            'members':['21021031', '17033730']
         })
         response = controller(request)
         assert response.status_code == 400
@@ -73,7 +77,8 @@ class Test_CreateProjectController:
             'description':'Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano',
             'po_RA':'21021031',
             'scrum_RA':'17033730',
-            'start_date':1649955600000
+            'start_date':1649955600000,
+            'members':['21021031', '17033730']
         })
 
         response = controller(request)
@@ -90,7 +95,8 @@ class Test_CreateProjectController:
             'name':'DevMedias',
             'po_RA':'21021031',
             'scrum_RA':'17033730',
-            'start_date':1649955600000
+            'start_date':1649955600000,
+            'members':['21021031', '17033730']
         })
 
         response = controller(request)
@@ -107,7 +113,8 @@ class Test_CreateProjectController:
             'name':'DevMedias',
             'description':'Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano',
             'scrum_RA':'17033730',
-            'start_date':1649955600000
+            'start_date':1649955600000,
+            'members':['17033730']
         })
 
         response = controller(request)
@@ -124,7 +131,8 @@ class Test_CreateProjectController:
             'name':'DevMedias',
             'description':'Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano',
             'po_RA':'21021031',
-            'start_date':1649955600000
+            'start_date':1649955600000,
+            'members':['21021031']
         })
 
         response = controller(request)
@@ -141,7 +149,8 @@ class Test_CreateProjectController:
             'name':'DevMedias',
             'description':'Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano',
             'po_RA':'21021031',
-            'scrum_RA':'17033730'
+            'scrum_RA':'17033730',
+            'members':['21021031', '17033730']
         })
 
         response = controller(request)
@@ -161,6 +170,7 @@ class Test_CreateProjectController:
                 'po_RA':'21021031',
                 'scrum_RA':'17033730',
                 'start_date':1649955600000,
+                'members':['21021031', '17033730'],
                 'photos':'https://i.imgur.com/7QF7uCk.png'
             })
     
@@ -181,9 +191,66 @@ class Test_CreateProjectController:
                     'po_RA':'21021031',
                     'scrum_RA':'17033730',
                     'start_date':1649955600000,
+                    'members':['21021031', '17033730'],
                     'photos':[1,2,3]
                 })
         
                 response = controller(request)
                 assert response.status_code == 400
                 assert response.body == 'Field photos is not valid'
+
+    def test_create_project_controller_missing_members(self):
+        
+        repo = ActionRepositoryMock()
+        usecase = CreateProjectUsecase(repo=repo)
+        controller = CreateProjectController(usecase=usecase)
+        request = HttpRequest(body = {
+            'code':'DM',
+            'name':'DevMedias',
+            'description':'Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano',
+            'po_RA':'21021031',
+            'scrum_RA':'17033730',
+            'start_date':1649955600000,
+        })
+
+        response = controller(request)
+        assert response.status_code == 400
+        assert response.body == 'Field members is missing'
+
+    def test_create_project_controller_wrong_type_members(self):
+            
+            repo = ActionRepositoryMock()
+            usecase = CreateProjectUsecase(repo=repo)
+            controller = CreateProjectController(usecase=usecase)
+            request = HttpRequest(body = {
+                'code':'DM',
+                'name':'DevMedias',
+                'description':'Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano',
+                'po_RA':'21021031',
+                'scrum_RA':'17033730',
+                'start_date':1649955600000,
+                'members':1
+            })
+    
+            response = controller(request)
+            assert response.status_code == 400
+            assert response.body == 'Field members is not valid'
+
+    def test_create_project_controller_members_not_list_of_str(self):
+                
+                repo = ActionRepositoryMock()
+                usecase = CreateProjectUsecase(repo=repo)
+                controller = CreateProjectController(usecase=usecase)
+                request = HttpRequest(body = {
+                    'code':'DM',
+                    'name':'DevMedias',
+                    'description':'Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano',
+                    'po_RA':'21021031',
+                    'scrum_RA':'17033730',
+                    'start_date':1649955600000,
+                    'members':[1,2,3]
+                })
+        
+                response = controller(request)
+                assert response.status_code == 400
+                assert response.body == 'Field members is not valid'

--- a/tests/modules/create_project/app/test_create_project_presenter.py
+++ b/tests/modules/create_project/app/test_create_project_presenter.py
@@ -50,7 +50,7 @@ class Test_CreateProjectPresenter:
                 "time": "12/Mar/2020:19:03:58 +0000",
                 "timeEpoch": 1583348638390
             },
-            "body": '{"code":"DM","name":"DevMedias","description":"Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano","po_RA":"21021031","scrum_RA":"17033730","start_date":1649955600000,"photos":["https://i.imgur.com/7QF7uCk.png"]}',
+            "body": '{"code":"DM","name":"DevMedias","description":"Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano","po_RA":"21021031","scrum_RA":"17033730","start_date":1649955600000,"members":["21021031","17033730"],"photos":["https://i.imgur.com/7QF7uCk.png"]}',
             "pathParameters": None,
             "isBase64Encoded": None,
             "stageVariables": None
@@ -65,6 +65,7 @@ class Test_CreateProjectPresenter:
                 'po_RA': '21021031',
                 'scrum_RA': '17033730',
                 'start_date': 1649955600000,
+                'members': ['17033730','21021031'],
                 'photos': [
                     'https://i.imgur.com/7QF7uCk.png'
                 ]
@@ -121,7 +122,7 @@ class Test_CreateProjectPresenter:
                 "time": "12/Mar/2020:19:03:58 +0000",
                 "timeEpoch": 1583348638390
             },
-            "body": '{"code":"DM","name":"DevMedias","description":"Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano","po_RA":"21021031","scrum_RA":"17033730","start_date":1649955600000}',
+            "body": '{"code":"DM","name":"DevMedias","description":"Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano","po_RA":"21021031","scrum_RA":"17033730","start_date":1649955600000,"members":["21021031","17033730"]}',
             "pathParameters": None,
             "isBase64Encoded": None,
             "stageVariables": None
@@ -136,6 +137,7 @@ class Test_CreateProjectPresenter:
                 'po_RA': '21021031',
                 'scrum_RA': '17033730',
                 'start_date': 1649955600000,
+                'members': ['17033730','21021031'],
                 'photos': []
             },
             'message': 'the project was created'
@@ -191,7 +193,7 @@ class Test_CreateProjectPresenter:
                 "time": "12/Mar/2020:19:03:58 +0000",
                 "timeEpoch": 1583348638390
             },
-            "body": '{"name":"DevMedias","description":"Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano","po_RA":"21021031","scrum_RA":"17033730","start_date":1649955600000,"photos":["https://i.imgur.com/7QF7uCk.png"]}',
+            "body": '{"name":"DevMedias","description":"Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano","po_RA":"21021031","scrum_RA":"17033730","start_date":1649955600000,"members":["21021031","17033730"],"photos":["https://i.imgur.com/7QF7uCk.png"]}',
             "pathParameters": None,
             "isBase64Encoded": None,
             "stageVariables": None
@@ -249,7 +251,7 @@ class Test_CreateProjectPresenter:
                 "time": "12/Mar/2020:19:03:58 +0000",
                 "timeEpoch": 1583348638390
             },
-            "body": '{"code":"DM","name":"DevMedias","description":"Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano","po_RA":"21021031","scrum_RA":"não tem","start_date":1649955600000,"photos":["https://i.imgur.com/7QF7uCk.png"]}',
+            "body": '{"code":"DM","name":"DevMedias","description":"Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano","po_RA":"21021031","scrum_RA":"não tem","start_date":1649955600000,"members":["21021031","17033730"],"photos":["https://i.imgur.com/7QF7uCk.png"]}',
             "pathParameters": None,
             "isBase64Encoded": None,
             "stageVariables": None

--- a/tests/modules/create_project/app/test_create_project_usecase.py
+++ b/tests/modules/create_project/app/test_create_project_usecase.py
@@ -8,7 +8,7 @@ class Test_CreateProjectUsecase:
         usecase = CreateProjectUsecase(repo=repo)
         lenBefore = len(repo.projects)
         
-        project = usecase(code='DM', name='DevMedias', description='Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano', po_RA='21021031', scrum_RA='17033730', start_date=1649955600000, photos=['https://i.imgur.com/7QF7uCk.png'])
+        project = usecase(code='DM', name='DevMedias', description='Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano', po_RA='21021031', scrum_RA='17033730', start_date=1649955600000, photos=['https://i.imgur.com/7QF7uCk.png'], members=['21021031', '17033730'])
         assert len(repo.projects) == lenBefore + 1
         assert project == repo.projects[-1]
         assert repo.projects[-1].code == 'DM'
@@ -19,7 +19,7 @@ class Test_CreateProjectUsecase:
         usecase = CreateProjectUsecase(repo=repo)
         lenBefore = len(repo.projects)
         
-        project = usecase(code='DM', name='DevMedias', description='Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano', po_RA='21021031', scrum_RA='17033730', start_date=1649955600000)
+        project = usecase(code='DM', name='DevMedias', description='Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano', po_RA='21021031', scrum_RA='17033730', start_date=1649955600000, members=['21021031', '17033730'])
         assert len(repo.projects) == lenBefore + 1
         assert project == repo.projects[-1]
         assert repo.projects[-1].code == 'DM'

--- a/tests/modules/create_project/app/test_create_project_viewmodel.py
+++ b/tests/modules/create_project/app/test_create_project_viewmodel.py
@@ -10,7 +10,8 @@ class Test_CreateProjectViewmodel:
             description='Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano', 
             po_RA='21021031', 
             scrum_RA='17033730', 
-            start_date=1649955600000, 
+            start_date=1649955600000,
+            members=['21021031', '17033730'],
             photos=['https://i.imgur.com/7QF7uCk.png']
             )
         viewmodel = CreateProjectViewmodel(project).to_dict()
@@ -22,6 +23,7 @@ class Test_CreateProjectViewmodel:
                 'po_RA':'21021031',
                 'scrum_RA':'17033730',
                 'start_date':1649955600000,
+                'members':['17033730','21021031'],
                 'photos':[
                     'https://i.imgur.com/7QF7uCk.png'
                 ]
@@ -38,7 +40,8 @@ class Test_CreateProjectViewmodel:
             description='Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano', 
             po_RA='21021031', 
             scrum_RA='17033730', 
-            start_date=1649955600000
+            start_date=1649955600000,
+            members=['21021031', '17033730']
             )
         viewmodel = CreateProjectViewmodel(project).to_dict()
         expected = {
@@ -49,6 +52,7 @@ class Test_CreateProjectViewmodel:
                 'po_RA':'21021031',
                 'scrum_RA':'17033730',
                 'start_date':1649955600000,
+                'members':['17033730','21021031'],
                 'photos':[]
             },
             'message':'the project was created'

--- a/tests/modules/delete_project/app/test_delete_project_presenter.py
+++ b/tests/modules/delete_project/app/test_delete_project_presenter.py
@@ -56,7 +56,7 @@ class Test_DeleteProjectPresenter:
         }
         
         response = lambda_handler(event, None)
-        expected = {'project': {'code': 'MF', 'name': 'Maua Food', 'description': 'É um aplicativo #foramoleza', 'po_RA': '21017310', 'scrum_RA': '21010757', 'start_date': 1634576165000, 'photos': ['https://i.imgur.com/gHoRKJU.png']}, 'message': 'the project was deleted'}
+        expected = {'project': {'code': 'MF', 'name': 'Maua Food', 'description': 'É um aplicativo #foramoleza', 'po_RA': '21017310', 'scrum_RA': '21010757', 'start_date': 1634576165000, 'members':['10017310','21010757', '21017310'], 'photos': ['https://i.imgur.com/gHoRKJU.png']}, 'message': 'the project was deleted'}
         
         assert response["statusCode"] == 200
         assert json.loads(response["body"]) == expected

--- a/tests/modules/delete_project/app/test_delete_project_viewmodel.py
+++ b/tests/modules/delete_project/app/test_delete_project_viewmodel.py
@@ -11,6 +11,7 @@ class Test_DeleteProjectViewModel:
             po_RA='21021031', 
             scrum_RA='17033730', 
             start_date=1649955600000, 
+            members=['21021031', '17033730'],
             photos=['https://i.imgur.com/7QF7uCk.png']
             )
         viewmodel = DeleteProjectViewModel(project).to_dict()
@@ -22,9 +23,8 @@ class Test_DeleteProjectViewModel:
                 'po_RA':'21021031',
                 'scrum_RA':'17033730',
                 'start_date':1649955600000,
-                'photos':[
-                    'https://i.imgur.com/7QF7uCk.png'
-                ]
+                'members':['17033730','21021031'],
+                'photos':['https://i.imgur.com/7QF7uCk.png']
             },
             'message':'the project was deleted'
             }
@@ -38,7 +38,8 @@ class Test_DeleteProjectViewModel:
             description='Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano', 
             po_RA='21021031', 
             scrum_RA='17033730', 
-            start_date=1649955600000
+            start_date=1649955600000,
+            members=['21021031', '17033730']
             )
         viewmodel = DeleteProjectViewModel(project).to_dict()
         expected = {
@@ -49,6 +50,7 @@ class Test_DeleteProjectViewModel:
                 'po_RA':'21021031',
                 'scrum_RA':'17033730',
                 'start_date':1649955600000,
+                'members':['17033730', '21021031'],
                 'photos':[]
             },
             'message':'the project was deleted'

--- a/tests/modules/get_all_projects/app/test_get_all_projects_usecase.py
+++ b/tests/modules/get_all_projects/app/test_get_all_projects_usecase.py
@@ -12,7 +12,4 @@ class Test_GetAllProjectsUsecase:
         projects = usecase()
         assert type(projects) == list
         assert len(projects) == 5
-        assert type(projects[0]) == tuple
-        assert type(projects[0][0]) == Project
-        for member in projects[0][1]:
-            assert type(member) == Member
+        assert type(projects[0]) == Project

--- a/tests/modules/get_all_projects/app/test_get_all_projects_viewmodel.py
+++ b/tests/modules/get_all_projects/app/test_get_all_projects_viewmodel.py
@@ -24,65 +24,7 @@ class Test_GetAllProjectsViewmodel:
                         'photos': [
                             'https://i.imgur.com/gHoRKJU.png'
                         ]
-                    },
-                    'members':[
-                        {
-                            'name': 'Vitor Guirão MPNTM',
-                            'email_dev': 'vsoller.devmaua@gmail.com',
-                            'email': 'vsoller@airubio.com',
-                            'ra': '21017310',
-                            'role': 'DIRECTOR',
-                            'stack': 'INFRA',
-                            'year': 1,
-                            'cellphone': '11991758098',
-                            'course': 'ECA',
-                            'hired_date': 1634576165000,
-                            'deactivated_date': None,
-                            'active': 'ACTIVE',
-                            'projects': [
-                                'MF'
-                            ]
-                        },
-                        {
-                            'name': 'Joao Branco',
-                            'email_dev': 'jbranco.devmaua@gmail.com',
-                            'email': 'jbranco@gmail.com',
-                            'ra': '21010757',
-                            'role': 'HEAD',
-                            'stack': 'BACKEND',
-                            'year': 3,
-                            'cellphone': '11991152348',
-                            'course': 'ECM',
-                            'hired_date': 1634921765000,
-                            'deactivated_date': None,
-                            'active': 'ACTIVE',
-                            'projects': [
-                                'MF',
-                                'PT',
-                                'SF'
-                            ]
-                        },
-                        {
-                            'name': 'Little Ronald',
-                            'email_dev': 'lronald.devmaua@gmail.com',
-                            'email': 'lronald@gmail.com',
-                            'ra': '10017310',
-                            'role': 'DIRECTOR',
-                            'stack': 'FRONTEND',
-                            'year': 6,
-                            'cellphone': '11991759998',
-                            'course': 'ECM',
-                            'hired_date': 1614567601000,
-                            'deactivated_date': None,
-                            'active': 'ACTIVE',
-                            'projects': [
-                                'MF',
-                                'PT',
-                                'SF',
-                                'SM'
-                            ]
-                        }
-                    ]
+                    }
                 },
                 {
                     'project': {
@@ -95,48 +37,7 @@ class Test_GetAllProjectsViewmodel:
                         'photos': [
                             'https://i.imgur.com/gHoRKJU.png'
                         ]
-                    },
-                    'members':[
-                        {
-                            'name': 'Joao Branco',
-                            'email_dev': 'jbranco.devmaua@gmail.com',
-                            'email': 'jbranco@gmail.com',
-                            'ra': '21010757',
-                            'role': 'HEAD',
-                            'stack': 'BACKEND',
-                            'year': 3,
-                            'cellphone': '11991152348',
-                            'course': 'ECM',
-                            'hired_date': 1634921765000,
-                            'deactivated_date': None,
-                            'active': 'ACTIVE',
-                            'projects': [
-                                'MF',
-                                'PT',
-                                'SF'
-                            ]
-                        },
-                        {
-                            'name': 'Little Ronald',
-                            'email_dev': 'lronald.devmaua@gmail.com',
-                            'email': 'lronald@gmail.com',
-                            'ra': '10017310',
-                            'role': 'DIRECTOR',
-                            'stack': 'FRONTEND',
-                            'year': 6,
-                            'cellphone': '11991759998',
-                            'course': 'ECM',
-                            'hired_date': 1614567601000,
-                            'deactivated_date': None,
-                            'active': 'ACTIVE',
-                            'projects': [
-                                'MF',
-                                'PT',
-                                'SF',
-                                'SM'
-                            ]
-                        }
-                    ]
+                    }
                 },
                 {
                     'project': {
@@ -149,66 +50,7 @@ class Test_GetAllProjectsViewmodel:
                         'photos': [
 
                         ]
-                    },
-                    'members':[
-                        {
-                            'name': 'Joao Branco',
-                            'email_dev': 'jbranco.devmaua@gmail.com',
-                            'email': 'jbranco@gmail.com',
-                            'ra': '21010757',
-                            'role': 'HEAD',
-                            'stack': 'BACKEND',
-                            'year': 3,
-                            'cellphone': '11991152348',
-                            'course': 'ECM',
-                            'hired_date': 1634921765000,
-                            'deactivated_date': None,
-                            'active': 'ACTIVE',
-                            'projects': [
-                                'MF',
-                                'PT',
-                                'SF'
-                            ]
-                        },
-                        {
-                            'name': 'Little Ronald',
-                            'email_dev': 'lronald.devmaua@gmail.com',
-                            'email': 'lronald@gmail.com',
-                            'ra': '10017310',
-                            'role': 'DIRECTOR',
-                            'stack': 'FRONTEND',
-                            'year': 6,
-                            'cellphone': '11991759998',
-                            'course': 'ECM',
-                            'hired_date': 1614567601000,
-                            'deactivated_date': None,
-                            'active': 'ACTIVE',
-                            'projects': [
-                                'MF',
-                                'PT',
-                                'SF',
-                                'SM'
-                            ]
-                        },
-                        {
-                            'name': 'Rubicks Cube',
-                            'email_dev': 'rcube.devmaua@gmail.com',
-                            'email': 'rubikscube@gmail.com',
-                            'ra': '19017311',
-                            'role': 'DEV',
-                            'stack': 'BACKEND',
-                            'year': 3,
-                            'cellphone': '11911758098',
-                            'course': 'ECM',
-                            'hired_date': 1640192165000,
-                            'deactivated_date': None,
-                            'active': 'ACTIVE',
-                            'projects': [
-                                'SM',
-                                'SF'
-                            ]
-                        }
-                    ]
+                    }
                 },
                 {
                     'project': {
@@ -221,47 +63,7 @@ class Test_GetAllProjectsViewmodel:
                         'photos': [
 
                         ]
-                    },
-                    'members':[
-                        {
-                            'name': 'Little Ronald',
-                            'email_dev': 'lronald.devmaua@gmail.com',
-                            'email': 'lronald@gmail.com',
-                            'ra': '10017310',
-                            'role': 'DIRECTOR',
-                            'stack': 'FRONTEND',
-                            'year': 6,
-                            'cellphone': '11991759998',
-                            'course': 'ECM',
-                            'hired_date': 1614567601000,
-                            'deactivated_date': None,
-                            'active': 'ACTIVE',
-                            'projects': [
-                                'MF',
-                                'PT',
-                                'SF',
-                                'SM'
-                            ]
-                        },
-                        {
-                            'name': 'Rubicks Cube',
-                            'email_dev': 'rcube.devmaua@gmail.com',
-                            'email': 'rubikscube@gmail.com',
-                            'ra': '19017311',
-                            'role': 'DEV',
-                            'stack': 'BACKEND',
-                            'year': 3,
-                            'cellphone': '11911758098',
-                            'course': 'ECM',
-                            'hired_date': 1640192165000,
-                            'deactivated_date': None,
-                            'active': 'ACTIVE',
-                            'projects': [
-                                'SM',
-                                'SF'
-                            ]
-                        }
-                    ]
+                    }
                 },
                 {
                     'project': {
@@ -274,10 +76,7 @@ class Test_GetAllProjectsViewmodel:
                         'photos': [
 
                         ]
-                    },
-                    'members':[
-
-                    ]
+                    }
                 }
             ],
             'message': 'the projects were retrieved'

--- a/tests/modules/get_member/app/test_get_member_controller.py
+++ b/tests/modules/get_member/app/test_get_member_controller.py
@@ -27,7 +27,6 @@ class Test_GetMemberController:
         assert response.body['member']['hired_date'] == repo.members[0].hired_date
         assert response.body['member']['active'] == repo.members[0].active.value
         assert response.body['member']['deactivated_date'] == repo.members[0].deactivated_date
-        assert response.body['member']['projects'] == repo.members[0].projects
         assert response.body['message'] == "the member was retrieved"
 
 

--- a/tests/modules/get_member/app/test_get_member_presenter.py
+++ b/tests/modules/get_member/app/test_get_member_presenter.py
@@ -69,7 +69,6 @@ class Test_GetMemberPresenter:
         assert json.loads(response['body'])['member']['course'] == 'ECA'
         assert json.loads(response['body'])['member']['hired_date'] == 1634576165000
         assert json.loads(response['body'])['member']['active'] == 'ACTIVE'
-        assert json.loads(response['body'])['member']['projects'] == ['MF']
         assert json.loads(response['body'])['member']['deactivated_date'] == None
 
     def test_get_member_presenter_invalid_ra(self):

--- a/tests/modules/get_member/app/test_get_member_viewmodel.py
+++ b/tests/modules/get_member/app/test_get_member_viewmodel.py
@@ -24,8 +24,7 @@ class Test_GetMemberViewModel:
                     'course': 'ECA',
                     'hired_date': 1634576165000,
                     'deactivated_date': None,
-                    'active': 'ACTIVE',
-                    'projects': ['MF']
+                    'active': 'ACTIVE'
             },
             "message" : "the member was retrieved"
         }

--- a/tests/modules/get_project/app/test_get_project_controller.py
+++ b/tests/modules/get_project/app/test_get_project_controller.py
@@ -16,7 +16,6 @@ class Test_GetProjectController:
         assert response.status_code == 200
         assert response.body['message'] == 'the project was retrieved'
         assert response.body['project']['code'] == 'MF'
-        assert len(response.body['members']) == 3
         
     def test_get_project_controller_missing_parameters(self):
         

--- a/tests/modules/get_project/app/test_get_project_usecase.py
+++ b/tests/modules/get_project/app/test_get_project_usecase.py
@@ -10,10 +10,9 @@ class Test_GetProjectUsecase:
         repo = ActionRepositoryMock()
         usecase = GetProjectUsecase(repo=repo)
 
-        project, members = usecase(code='MF')
+        project= usecase(code='MF')
         assert project.code == 'MF'
         assert type(project) == Project
-        assert type(members) == list
 
     def test_get_project_usecase_no_items_found(self):
         repo = ActionRepositoryMock()

--- a/tests/modules/get_project/app/test_get_project_viewmodel.py
+++ b/tests/modules/get_project/app/test_get_project_viewmodel.py
@@ -7,10 +7,10 @@ class Test_GetProjectViewmodel:
     def test_get_project_viewmodel(self):
         repo = ActionRepositoryMock()
         usecase = GetProjectUsecase(repo=repo)
-        project, members = usecase(code='MF')
+        project = usecase(code='MF')
 
         viewmodel = GetProjectViewmodel(
-            project=project, members=members).to_dict()
+            project=project).to_dict()
 
         expected = {
             'project': {
@@ -24,53 +24,53 @@ class Test_GetProjectViewmodel:
                     'https://i.imgur.com/gHoRKJU.png'
                 ]
             },
-            'members': [
-                {
-                    'name': 'Vitor Guirão MPNTM',
-                    'email_dev': 'vsoller.devmaua@gmail.com',
-                    'email': 'vsoller@airubio.com',
-                    'ra': '21017310',
-                    'role': 'DIRECTOR',
-                    'stack': 'INFRA',
-                    'year': 1,
-                    'cellphone': '11991758098',
-                    'course': 'ECA',
-                    'hired_date': 1634576165000,
-                    'deactivated_date': None,
-                    'active': 'ACTIVE',
-                    'projects': ['MF']
-                },
-                {
-                    'name': 'Joao Branco',
-                    'email_dev': 'jbranco.devmaua@gmail.com',
-                    'email': 'jbranco@gmail.com',
-                    'ra': '21010757',
-                    'role': 'HEAD',
-                    'stack': 'BACKEND',
-                    'year': 3,
-                    'cellphone': '11991152348',
-                    'course': 'ECM',
-                    'hired_date': 1634921765000,
-                    'deactivated_date': None,
-                    'active': 'ACTIVE',
-                    'projects': ['MF','PT','SF']
-                },
-                {
-                    'name': 'Little Ronald',
-                    'email_dev': 'lronald.devmaua@gmail.com',
-                    'email': 'lronald@gmail.com',
-                    'ra': '10017310',
-                    'role': 'DIRECTOR',
-                    'stack': 'FRONTEND',
-                    'year': 6,
-                    'cellphone': '11991759998',
-                    'course': 'ECM',
-                    'hired_date': 1614567601000,
-                    'deactivated_date': None,
-                    'active': 'ACTIVE',
-                    'projects': ['MF','PT','SF','SM']
-                }
-            ],
+            # 'members': [
+            #     {
+            #         'name': 'Vitor Guirão MPNTM',
+            #         'email_dev': 'vsoller.devmaua@gmail.com',
+            #         'email': 'vsoller@airubio.com',
+            #         'ra': '21017310',
+            #         'role': 'DIRECTOR',
+            #         'stack': 'INFRA',
+            #         'year': 1,
+            #         'cellphone': '11991758098',
+            #         'course': 'ECA',
+            #         'hired_date': 1634576165000,
+            #         'deactivated_date': None,
+            #         'active': 'ACTIVE',
+            #         'projects': ['MF']
+            #     },
+            #     {
+            #         'name': 'Joao Branco',
+            #         'email_dev': 'jbranco.devmaua@gmail.com',
+            #         'email': 'jbranco@gmail.com',
+            #         'ra': '21010757',
+            #         'role': 'HEAD',
+            #         'stack': 'BACKEND',
+            #         'year': 3,
+            #         'cellphone': '11991152348',
+            #         'course': 'ECM',
+            #         'hired_date': 1634921765000,
+            #         'deactivated_date': None,
+            #         'active': 'ACTIVE',
+            #         'projects': ['MF','PT','SF']
+            #     },
+            #     {
+            #         'name': 'Little Ronald',
+            #         'email_dev': 'lronald.devmaua@gmail.com',
+            #         'email': 'lronald@gmail.com',
+            #         'ra': '10017310',
+            #         'role': 'DIRECTOR',
+            #         'stack': 'FRONTEND',
+            #         'year': 6,
+            #         'cellphone': '11991759998',
+            #         'course': 'ECM',
+            #         'hired_date': 1614567601000,
+            #         'deactivated_date': None,
+            #         'active': 'ACTIVE',
+            #         'projects': ['MF','PT','SF','SM']
+            #     }
+            # ],
             'message': 'the project was retrieved'
         }
 

--- a/tests/modules/get_project/app/test_get_project_viewmodel.py
+++ b/tests/modules/get_project/app/test_get_project_viewmodel.py
@@ -24,53 +24,6 @@ class Test_GetProjectViewmodel:
                     'https://i.imgur.com/gHoRKJU.png'
                 ]
             },
-            # 'members': [
-            #     {
-            #         'name': 'Vitor Guirão MPNTM',
-            #         'email_dev': 'vsoller.devmaua@gmail.com',
-            #         'email': 'vsoller@airubio.com',
-            #         'ra': '21017310',
-            #         'role': 'DIRECTOR',
-            #         'stack': 'INFRA',
-            #         'year': 1,
-            #         'cellphone': '11991758098',
-            #         'course': 'ECA',
-            #         'hired_date': 1634576165000,
-            #         'deactivated_date': None,
-            #         'active': 'ACTIVE',
-            #         'projects': ['MF']
-            #     },
-            #     {
-            #         'name': 'Joao Branco',
-            #         'email_dev': 'jbranco.devmaua@gmail.com',
-            #         'email': 'jbranco@gmail.com',
-            #         'ra': '21010757',
-            #         'role': 'HEAD',
-            #         'stack': 'BACKEND',
-            #         'year': 3,
-            #         'cellphone': '11991152348',
-            #         'course': 'ECM',
-            #         'hired_date': 1634921765000,
-            #         'deactivated_date': None,
-            #         'active': 'ACTIVE',
-            #         'projects': ['MF','PT','SF']
-            #     },
-            #     {
-            #         'name': 'Little Ronald',
-            #         'email_dev': 'lronald.devmaua@gmail.com',
-            #         'email': 'lronald@gmail.com',
-            #         'ra': '10017310',
-            #         'role': 'DIRECTOR',
-            #         'stack': 'FRONTEND',
-            #         'year': 6,
-            #         'cellphone': '11991759998',
-            #         'course': 'ECM',
-            #         'hired_date': 1614567601000,
-            #         'deactivated_date': None,
-            #         'active': 'ACTIVE',
-            #         'projects': ['MF','PT','SF','SM']
-            #     }
-            # ],
             'message': 'the project was retrieved'
         }
 

--- a/tests/shared/domain/entities/test_member.py
+++ b/tests/shared/domain/entities/test_member.py
@@ -22,10 +22,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1614567601000,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
         
         assert member.name == "Vitor Guirão MPNTM"
@@ -39,9 +36,6 @@ class Test_Member:
         assert member.course == COURSE.ECA
         assert member.hired_date == 1614567601000
         assert member.active == ACTIVE.FREEZE
-        assert len(member.projects) == 1
-
-        assert member.projects[0] == "MF"
 
             
     def test_member_name_not_str(self): 
@@ -57,10 +51,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
             
     def test_member_name_smaller_than_minimum(self): 
@@ -76,10 +67,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
 
     def test_member_ra_not_str(self): 
@@ -95,10 +83,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-              
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
 
     def test_member_ra_not_decimal(self): 
@@ -114,10 +99,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
 
     def test_member_lenght_ra_not_8(self): 
@@ -133,10 +115,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
 
 
@@ -153,10 +132,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
             
     def test_member_email_dev_is_not_in_right_format(self): 
@@ -172,10 +148,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
             
     
@@ -192,10 +165,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
 
     def test_member_email_is_not_str(self):
@@ -211,8 +181,7 @@ class Test_Member:
             cellphone="11991758098",
             course="COURSE.ECA",
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-            projects=["MF"]
+            active=ACTIVE.FREEZE
             )
 
     def test_member_email_is_not_in_right_format(self):
@@ -228,8 +197,7 @@ class Test_Member:
             cellphone="11991758098",
             course="COURSE.ECA",
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-            projects=["MF"]
+            active=ACTIVE.FREEZE
             )    
 
     def test_member_email_is_the_same_as_email_dev(self):
@@ -245,8 +213,7 @@ class Test_Member:
             cellphone="11991758098",
             course="COURSE.ECA",
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-            projects=["MF"]
+            active=ACTIVE.FREEZE
             )
     
     def test_member_role_not_enum(self): 
@@ -262,10 +229,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
 
     def test_member_stack_not_enum(self): 
@@ -281,10 +245,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
 
     def test_member_year_not_int(self): 
@@ -300,10 +261,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
             
     def test_member_year_bigger_than_6(self): 
@@ -319,10 +277,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
             
     def test_member_year_smaller_than_0(self): 
@@ -338,10 +293,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
 
     def test_member_cellphone_not_str(self): 
@@ -357,10 +309,7 @@ class Test_Member:
             cellphone=11991758098,
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
 
     def test_member_cellphone_not_in_right_format(self): 
@@ -376,10 +325,7 @@ class Test_Member:
             cellphone="551991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
 
 
@@ -396,10 +342,7 @@ class Test_Member:
             cellphone="11991758098",
             course="COURSE.ECA",
             hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
 
 
@@ -416,10 +359,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date="10/10/2002",
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
             
     def test_member_hired_date_less_than_zero(self): 
@@ -435,10 +375,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=-1671728165,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF"]
-
+            active=ACTIVE.FREEZE
         )
             
     def test_member_active_not_enum(self): 
@@ -454,10 +391,7 @@ class Test_Member:
             cellphone="11991758098",
             course=COURSE.ECA,
             hired_date=1671728165,
-            active="ACTIVE.FREEZE",
-
-            projects=["MF"]
-
+            active="ACTIVE.FREEZE"
         )
             
     def test_member_active_with_deactivated_date(self): 
@@ -474,124 +408,8 @@ class Test_Member:
             course=COURSE.ECA,
             hired_date=1671728165,
             deactivated_date=1671728165,
-            active=ACTIVE.ACTIVE,
-
-            projects=["MF"]
-
+            active=ACTIVE.ACTIVE
         )
-
-    def test_member_projects_is_none(self): 
-        member = Member(
-            name="Vitor Guirão MPNTM",
-            email_dev="vsoller.devmaua@gmail.com",
-            email="vsoller@airubio.com",
-            ra="21017310",
-            role=ROLE.DIRECTOR,
-            stack=STACK.INFRA,
-            year=1,
-            cellphone="11991758098",
-            course=COURSE.ECA,
-            hired_date=1614567601000,
-            active=ACTIVE.FREEZE,
-            deactivated_date=1677639601000
-        )
-        
-        assert member.projects == []
-        
-
-    def test_member_projects_is_not_list(self): 
-        with pytest.raises(EntityError):
-            Member(
-            name="Vitor Guirão MPNTM",
-            email_dev="vsoller.devmaua@gmail.com",
-            email="vsoller@airubio.com",
-            ra="21017310",
-            role=ROLE.DIRECTOR,
-            stack=STACK.INFRA,
-            year=2021,
-            cellphone="11991758098",
-            course=COURSE.ECA,
-            hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-            projects="[]"
-            
-        )
-
-    def test_member_projects_is_not_list_of_str(self): 
-        with pytest.raises(EntityError):
-            Member(
-            name="Vitor Guirão MPNTM",
-            email_dev="vsoller.devmaua@gmail.com",
-            email="vsoller@airubio.com",
-            ra="21017310",
-            role=ROLE.DIRECTOR,
-            stack=STACK.INFRA,
-            year=2021,
-            cellphone="11991758098",
-            course=COURSE.ECA,
-            hired_date=1671728165,
-            active=ACTIVE.FREEZE,
-            projects=[1,2,3]
-        )
-
-    def test_member_projects_is_not_list_of_str_with_2_items(self): 
-        with pytest.raises(EntityError):
-            Member(
-                name="Vitor Guirão MPNTM",
-                email_dev="vsoller.devmaua@gmail.com",
-                email="vsoller@airubio.com",
-                ra="21017310",
-                role=ROLE.DIRECTOR,
-                stack=STACK.INFRA,
-                year=2021,
-                cellphone="11991758098",
-                course=COURSE.ECA,
-                hired_date=1671728165,
-                active=ACTIVE.FREEZE,
-
-                projects=["MF", 1]
-
-            )
-    
-    def test_member_projects_is_list_of_str_with_2_items(self): 
-        
-        member = Member(
-            name="Vitor Guirão MPNTM",
-            email_dev="vsoller.devmaua@gmail.com",
-            email="vsoller@airubio.com",
-            ra="21017310",
-            role=ROLE.DIRECTOR,
-            stack=STACK.INFRA,
-            year=1,
-            cellphone="11991758098",
-            course=COURSE.ECA,
-            hired_date=1614567601000,
-            active=ACTIVE.FREEZE,
-
-            projects=["MF", "SM"]
-
-        )            
-        assert len(member.projects) == 2
-
-    def test_member_deactivated_date_not_none_or_int(self): 
-        with pytest.raises(EntityError):
-            Member(
-                name="Vitor Guirão MPNTM",
-                email_dev="vsoller.devmaua@gmail.com",
-                email="vsoller@airubio.com",
-                ra="21017310",
-                role=ROLE.DIRECTOR,
-                stack=STACK.INFRA,
-                year=1,
-                cellphone="11991758098",
-                course=COURSE.ECA,
-                hired_date=1671728165,
-                active=ACTIVE.DISCONNECTED,
-
-                projects=["MF", "SM"],
-
-                deactivated_date="10/10/2022"
-            )     
                  
     def test_member_deactivated_date_smaller_than_hired_date(self): 
         with pytest.raises(EntityError):
@@ -607,8 +425,5 @@ class Test_Member:
                 course=COURSE.ECA,
                 hired_date=1671728165,
                 active=ACTIVE.DISCONNECTED,
-
-                projects=["MF", "SM"],
-
                 deactivated_date=1640192165
             )          

--- a/tests/shared/domain/entities/test_project.py
+++ b/tests/shared/domain/entities/test_project.py
@@ -14,7 +14,8 @@ class Test_Project():
             scrum_RA="22011020",
             start_date=1672585200000,
             photos=['https://i.imgur.com/gHoRKJU.png',
-                    'https://i.imgur.com/gHoRKJU.png']
+                    'https://i.imgur.com/gHoRKJU.png'],
+            members=['22011020']
         )
         assert type(project) == Project
         assert project.photos != []
@@ -29,7 +30,8 @@ class Test_Project():
                 scrum_RA="22011020",
                 start_date=1672585200000,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png']
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020']
             )
 
     def test_project_code_must_be_2_characters(self):
@@ -42,7 +44,8 @@ class Test_Project():
                 scrum_RA="22011020",
                 start_date=1672585200000,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png']
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020']
             )
 
     def test_project_code_must_be_alphabetical(self):
@@ -55,7 +58,8 @@ class Test_Project():
                 scrum_RA="22011020",
                 start_date=1672585200000,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png']
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020']
             )
 
     def test_project_code_must_be_uppercase(self):
@@ -68,7 +72,8 @@ class Test_Project():
                 scrum_RA="22011020",
                 start_date=1672585200000,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png']
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020']
             )
 
     def test_project_name_must_be_str(self):
@@ -81,7 +86,8 @@ class Test_Project():
                 scrum_RA="22011020",
                 start_date=1672585200000,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png']
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020']
             )
 
     def test_project_description_must_be_str(self):
@@ -94,7 +100,8 @@ class Test_Project():
                 scrum_RA="22011020",
                 start_date=1672585200000,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png']
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020']
             )
 
     def test_project_po_RA_must_be_str(self):
@@ -107,7 +114,8 @@ class Test_Project():
                 scrum_RA="22011020",
                 start_date=1672585200000,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png']
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020']
             )
 
     def test_project_po_ra_must_be_8_characters(self):
@@ -120,7 +128,8 @@ class Test_Project():
                 scrum_RA="22011020",
                 start_date=1672585200000,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png']
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020']
             )
 
     def test_project_po_ra_must_be_decimal(self):
@@ -133,7 +142,8 @@ class Test_Project():
                 scrum_RA="22011020",
                 start_date=1672585200000,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png']
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020']
             )
     
     def test_project_scrum_RA_must_be_str(self):
@@ -146,7 +156,8 @@ class Test_Project():
                 scrum_RA=1,
                 start_date=1672585200000,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png'] 
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020']
             )
             
     def test_project_scrum_ra_must_be_8_characters(self):
@@ -159,7 +170,8 @@ class Test_Project():
                 scrum_RA="2201102",
                 start_date=1672585200000,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png'] 
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020']
             )
             
     def test_project_scrum_ra_must_be_decimal(self):
@@ -172,7 +184,8 @@ class Test_Project():
                 scrum_RA="2201102a",
                 start_date=1672585200000,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png'] 
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020']
             )
             
     def test_project_start_date_must_be_int(self):
@@ -185,7 +198,8 @@ class Test_Project():
                 scrum_RA="22011020",
                 start_date="1672585200000",
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png'] 
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020'] 
             )
             
     def test_project_start_date_must_be_greater_than_0(self):
@@ -198,7 +212,8 @@ class Test_Project():
                 scrum_RA="22011020",
                 start_date=-362,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png'] 
+                        'https://i.imgur.com/gHoRKJU.png'], 
+                members=['22011020']
             )
             
     def test_project_start_date_must_be_smaller_than_now(self):
@@ -212,7 +227,8 @@ class Test_Project():
                 scrum_RA="22011020",
                 start_date=now + 3000,
                 photos=['https://i.imgur.com/gHoRKJU.png',
-                        'https://i.imgur.com/gHoRKJU.png'] 
+                        'https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020']
             )
             
     def test_project_photos_can_be_none(self):
@@ -223,6 +239,7 @@ class Test_Project():
             po_RA="22011020",
             scrum_RA="22011020",
             start_date=1672585200000,
+            members=['22011020']
         )
         assert project.photos == []
         
@@ -235,5 +252,72 @@ class Test_Project():
                 po_RA="22011020",
                 scrum_RA="22011020",
                 start_date=1672585200000,
-                photos='https://i.imgur.com/gHoRKJU.png'
+                photos='https://i.imgur.com/gHoRKJU.png',
+                members=['22011020']
+            )
+
+    def test_project_members_must_be_list(self):
+        with pytest.raises(EntityError):
+            Project(
+                code='MF',
+                name='test_project',
+                description='test_description',
+                po_RA="22011020",
+                scrum_RA="22011020",
+                start_date=1672585200000,
+                photos=['https://i.imgur.com/gHoRKJU.png'],
+                members='22011020'
+            )
+
+    def test_project_members_less_than_one(self):
+        with pytest.raises(EntityError):
+            Project(
+                code='MF',
+                name='test_project',
+                description='test_description',
+                po_RA="22011020",
+                scrum_RA="22011020",
+                start_date=1672585200000,
+                photos=['https://i.imgur.com/gHoRKJU.png'],
+                members=[]
+            )
+
+    def test_project_members_invalid_ra(self):
+        with pytest.raises(EntityError):
+            Project(
+                code='MF',
+                name='test_project',
+                description='test_description',
+                po_RA="22011020",
+                scrum_RA="22011020",
+                start_date=1672585200000,
+                photos=['https://i.imgur.com/gHoRKJU.png'],
+                members=['22011020', '2201102a']
+            )
+
+    def test_project_members_duplicated_member(self):
+        project = Project(
+            code='PQ',
+            name='test_project',
+            description='test_description',
+            po_RA="22011020",
+            scrum_RA="22011121",
+            start_date=1672585200000,
+            photos=['https://i.imgur.com/gHoRKJU.png'],
+            members=['22011020', '22011020', '22011121']
+        )
+
+        assert project.members == ['22011020','22011121']
+
+    def test_project_po_RA_not_in_members(self):
+        with pytest.raises(EntityError):
+            Project(
+                code='PQ',
+                name='test_project',
+                description='test_description',
+                po_RA="22011020",
+                scrum_RA="22011121",
+                start_date=1672585200000,
+                photos=['https://i.imgur.com/gHoRKJU.png'],
+                members=['22011022', '22011121']
             )

--- a/tests/shared/domain/entities/test_project.py
+++ b/tests/shared/domain/entities/test_project.py
@@ -307,7 +307,7 @@ class Test_Project():
             members=['22011020', '22011020', '22011121']
         )
 
-        assert project.members == ['22011020','22011121']
+        assert project.members == ['22011020', '22011121']
 
     def test_project_po_RA_not_in_members(self):
         with pytest.raises(EntityError):

--- a/tests/shared/domain/entities/test_project.py
+++ b/tests/shared/domain/entities/test_project.py
@@ -321,3 +321,37 @@ class Test_Project():
                 photos=['https://i.imgur.com/gHoRKJU.png'],
                 members=['22011022', '22011121']
             )
+
+    def test_project_change_po_RA(self):
+        project = Project(
+            code='PQ',
+            name='test_project',
+            description='test_description',
+            po_RA="22011020",
+            scrum_RA="22011121",
+            start_date=1672585200000,
+            photos=['https://i.imgur.com/gHoRKJU.png'],
+            members=['22011020', '22011121']
+        )
+
+        project.change_po_RA('22001022')
+
+        assert project.po_RA == '22001022'
+        assert project.members == ['22001022', '22011121']
+
+    def test_project_change_scrum_RA(self):
+        project = Project(
+            code='PQ',
+            name='test_project',
+            description='test_description',
+            po_RA="22011020",
+            scrum_RA="22011121",
+            start_date=1672585200000,
+            photos=['https://i.imgur.com/gHoRKJU.png'],
+            members=['22011020', '22011121']
+        )
+
+        project.change_scrum_RA('22001022')
+
+        assert project.scrum_RA == '22001022'
+        assert project.members == ['22001022','22011020']

--- a/tests/shared/infra/repositories/test_action_repository_mock.py
+++ b/tests/shared/infra/repositories/test_action_repository_mock.py
@@ -46,7 +46,7 @@ class Test_ActionRepositoryMock:
     def test_create_project(self):
         repo = ActionRepositoryMock()
         len_before = len(repo.projects)
-        project = repo.create_project(project=Project(code='DM', name='DevMedias', description='Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano', po_RA='21021031', scrum_RA='17033730', start_date=1649955600000, photos=['https://i.imgur.com/7QF7uCk.png']))
+        project = repo.create_project(project=Project(code='DM', name='DevMedias', description='Projeto que calcula a média de notas e quanto um aluno precisa tirar para passar de ano', po_RA='21021031', scrum_RA='17033730', start_date=1649955600000, photos=['https://i.imgur.com/7QF7uCk.png'], members=['21021031', '17033730']))
         assert len(repo.projects) == len_before + 1
         assert project == repo.projects[-1]
         assert repo.projects[-1].code == 'DM'

--- a/tests/shared/infra/repositories/test_action_repository_mock.py
+++ b/tests/shared/infra/repositories/test_action_repository_mock.py
@@ -58,12 +58,6 @@ class Test_ActionRepositoryMock:
         project = repo.delete_project(code='MF')
         assert len(repo.projects) == len_before - 1
         assert project.code == 'MF'
-
-    def test_get_members_by_project(self):
-        repo = ActionRepositoryMock()
-        associated_members = repo.get_members_by_project('MF')
-        assert type(associated_members) == list
-        assert len(associated_members) == 3
         
     def test_get_project(self):
         repo = ActionRepositoryMock()


### PR DESCRIPTION
a entidade member não possui mais uma lista com os códigos dos projetos que participa. A entidade project agora possui uma lista com os RA's dos membros participante do projeto, que obrigatoriamente deve incluir os RA's do po e scrum. Isso também implica em pequenas mudanças em algumas rotas