### PR TITLE
fix: change the method get_active_heads_and_directors to do the searc…

### DIFF
--- a/iac/iac/dynamo_stack.py
+++ b/iac/iac/dynamo_stack.py
@@ -95,18 +95,6 @@ class DynamoStack(Construct):
                     billing_mode=aws_dynamodb.BillingMode.PAY_PER_REQUEST,
                     removal_policy=REMOVAL_POLICY
                 )  
-
-                self.dynamo_table_member.add_global_secondary_index(
-                    partition_key=aws_dynamodb.Attribute(
-                        name="GSI-ROLE-PK",
-                        type=aws_dynamodb.AttributeType.STRING
-                    ),
-                    sort_key=aws_dynamodb.Attribute(
-                        name="GSI-ROLE-SK",
-                        type=aws_dynamodb.AttributeType.STRING
-                    ),
-                    index_name="GSI-ROLE"
-                )  
                 CfnOutput(self, 'DynamoActionRemovalPolicy',
                     value=REMOVAL_POLICY.value,
                     export_name=f'PortalInterno{self.github_ref_name}DynamoActionRemovalPolicyValue')

--- a/src/shared/environments.py
+++ b/src/shared/environments.py
@@ -57,8 +57,6 @@ class Environments:
             self.dynamo_gsi_1_sort_key = "GSI1-SK"
             self.dynamo_gsi_strike_partition_key = "GSI-TARGET-PK"
             self.dynamo_gsi_strike_sort_key= "GSI-TARGET-SK"
-            self.dynamo_gsi_member_partition_key= "GSI-ROLE-PK"
-            self.dynamo_gsi_member_sort_key= "GSI-ROLE-SK"
             self.cloud_front_distribution_domain_assets_member = "https://d3q9q9q9q9q9q9.cloudfront.net"
             self.cloud_front_distribution_domain_assets_project = "https://d3q9q9q9q9q9q9.cloudfront.net"
             self.cloud_front_distribution_domain_assets_member_report = "https://d3q9q9q9q9q9q9.cloudfront.net"
@@ -84,8 +82,6 @@ class Environments:
             self.dynamo_gsi_1_sort_key = os.environ.get("DYNAMO_GSI_SORT_KEY")
             self.dynamo_gsi_strike_partition_key= os.environ.get("DYNAMO_GSI_TARGET_PARTITION_KEY")
             self.dynamo_gsi_strike_sort_key= os.environ.get("DYNAMO_GSI_TARGET_SORT_KEY")
-            self.dynamo_gsi_member_partition_key= os.environ.get("DYNAMO_GSI_TARGET_PARTITION_KEY")
-            self.dynamo_gsi_member_sort_key= os.environ.get("DYNAMO_GSI_TARGET_SORT_KEY")
             self.cloud_front_distribution_domain_assets_member = os.environ.get("CLOUD_FRONT_DISTRIBUTION_DOMAIN_ASSETS_MEMBER")
             self.cloud_front_distribution_domain_assets_project = os.environ.get("CLOUD_FRONT_DISTRIBUTION_DOMAIN_ASSETS_PROJECT")
             self.cloud_front_distribution_domain_assets_member_report = os.environ.get("CLOUD_FRONT_DISTRIBUTION_DOMAIN_ASSETS_MEMBER_REPORT")

--- a/src/shared/infra/repositories/load_member_mock_to_dynamo.py
+++ b/src/shared/infra/repositories/load_member_mock_to_dynamo.py
@@ -25,25 +25,6 @@ def setup_dynamo_table():
                     'KeyType': 'RANGE'
                 }
             ],
-            GlobalSecondaryIndexes=[
-                {
-                    'IndexName': 'GSI-ROLE',
-                    'KeySchema': [
-                        {
-                            'KeyType': 'HASH',
-                            'AttributeName': 'GSI-ROLE-PK'
-                        },
-                        {
-                            'KeyType': 'RANGE',
-                            'AttributeName': 'GSI-ROLE-SK'
-                        }
-                    ],
-                    'Projection': {
-                        'ProjectionType': 'ALL'
-                    }
-                },
-
-            ],
             AttributeDefinitions=[
                 {
                     'AttributeName': 'PK',
@@ -52,14 +33,6 @@ def setup_dynamo_table():
                 {
                     'AttributeName': 'SK',
                     'AttributeType': 'S'
-                },
-                {
-                    'AttributeName': 'GSI-ROLE-PK',
-                    "AttributeType": 'S'
-                },
-                {
-                    'AttributeName': 'GSI-ROLE-SK',
-                    "AttributeType": 'S'
                 }
             ],
             

--- a/src/shared/infra/repositories/member_repository_dynamo.py
+++ b/src/shared/infra/repositories/member_repository_dynamo.py
@@ -19,6 +19,7 @@ from src.shared.domain.enums.role_enum import ROLE
 from src.shared.domain.enums.stack_enum import STACK
 from src.shared.helpers.utils.compose_member_active_email import compose_member_active_email
 import boto3
+from boto3.dynamodb.conditions import Attr
 
 
 class MemberRepositoryDynamo(IMemberRepository):
@@ -30,21 +31,12 @@ class MemberRepositoryDynamo(IMemberRepository):
     def member_sort_key_format(user_id: str) -> str:
         return f'member#{user_id}'
     
-    @staticmethod
-    def gsi_member_partition_key_format(role: ROLE) -> str:
-        return role.value
-
-    @staticmethod
-    def gsi_member_sort_key_format(active: ACTIVE) -> str:
-        return active.value
-    
     def __init__(self):
         self.dynamo = DynamoDatasource(
             endpoint_url=Environments.get_envs().endpoint_url,
             dynamo_table_name=Environments.get_envs().dynamo_table_name_member,
             region=Environments.get_envs().region,
-            partition_key=Environments.get_envs().dynamo_partition_key,sort_key=Environments.get_envs().dynamo_sort_key,gsi_partition_key=Environments.get_envs().dynamo_gsi_member_partition_key,
-            gsi_sort_key=Environments.get_envs().dynamo_gsi_member_sort_key
+            partition_key=Environments.get_envs().dynamo_partition_key,sort_key=Environments.get_envs().dynamo_sort_key
         )
         
         my_config = Config(
@@ -65,9 +57,6 @@ class MemberRepositoryDynamo(IMemberRepository):
             member.photo = url
 
         item = MemberDynamoDTO.from_entity(member).to_dynamo()
-
-        item['GSI-ROLE-PK']= self.gsi_member_partition_key_format(member.role)
-        item['GSI-ROLE-SK']= self.gsi_member_sort_key_format(member.active)
 
         self.dynamo.put_item(
             item=item,
@@ -97,25 +86,19 @@ class MemberRepositoryDynamo(IMemberRepository):
         return member_dto.to_entity()
     
     def get_active_heads_and_directors(self) -> Optional[List[Member]]:
-        head_response= self.dynamo.query(
-            IndexName= "GSI-ROLE",
-            key_condition_expression= Key('GSI-ROLE-PK').eq("HEAD") & Key('GSI-ROLE-SK').eq("ACTIVE")
+
+        filter= Attr('ACTIVE').eq("ACTIVE") & Attr('ROLE').isin(["HEAD", "DIRECTOR"])
+
+        response = self.dynamo.scan_items(
+            filter_expression=filter
         )
 
-        director_response= self.dynamo.query(
-            IndexName= "GSI-ROLE",
-            key_condition_expression= Key('GSI-ROLE-PK').eq("DIRECTOR") & Key('GSI-ROLE-SK').eq("ACTIVE")
-        )
+        items = response.get("Items", [])
 
-        active_heads= head_response.get('Items', [])
-        active_directors= director_response.get('Items', [])
-
-        active_head_and_directors= active_heads + active_directors
-
-        if not active_head_and_directors:
+        if not items:
             return None
         
-        active_head_and_director_list= [MemberDynamoDTO.from_dynamo(active_head_or_director).to_entity() for active_head_or_director in active_head_and_directors]
+        active_head_and_director_list= [MemberDynamoDTO.from_dynamo(active_head_or_director).to_entity() for active_head_or_director in items]
 
         return active_head_and_director_list
     
@@ -180,8 +163,6 @@ class MemberRepositoryDynamo(IMemberRepository):
             "cellphone": member_to_update.cellphone,
             "course": member_to_update.course.value,
             "active": member_to_update.active.value,
-            "GSI-ROLE-PK": member_to_update.role.value,
-            "GSI-ROLE-SK": member_to_update.active.value,
             "deactivated_date": member_to_update.deactivated_date if new_deactivated_date is not None else None,
             "photo": url if new_photo is not None else None
         }

--- a/tests/shared/infra/repositories/test_member_repository_dynamo.py
+++ b/tests/shared/infra/repositories/test_member_repository_dynamo.py
@@ -141,18 +141,18 @@ class Test_MemberRepositoryDynamo:
         assert active_heads_and_directors == expected_active
     
     @pytest.mark.skip("Can't run test in github actions")
-    def test_get_active_heads_and_directors_with_gsi(self):
-        """Test that get_active_heads_and_directors correctly uses the GSI-ROLE index for both HEAD and DIRECTOR"""
+    def test_get_active_heads_and_directors_scan_filter(self):
+        """Test that get_active_heads_and_directors correctly uses scan with filter for both HEAD and DIRECTOR roles"""
         repo = MemberRepositoryDynamo()
         
-        # This test verifies the GSI query is working for both roles
+        # This test verifies the scan filter is working correctly for both roles
         active_heads_and_directors = repo.get_active_heads_and_directors()
         
         # Should return 4 active members (1 HEAD + 3 DIRECTORs from mock data)
         assert active_heads_and_directors is not None
         assert len(active_heads_and_directors) == 4
         
-        # Verify all returned members match the GSI query criteria
+        # Verify all returned members match the scan filter criteria
         for member in active_heads_and_directors:
             assert member.role in [ROLE.HEAD, ROLE.DIRECTOR]
             assert member.active == ACTIVE.ACTIVE


### PR DESCRIPTION
This pull request removes the use of the `GSI-ROLE` global secondary index from the DynamoDB member table and refactors related code to use scan with attribute filters instead. The changes affect infrastructure setup, environment configuration, repository logic, and related tests. The refactor simplifies the member querying logic and removes unnecessary environment variables and code paths related to the GSI.

**DynamoDB Table and Infrastructure Changes**
* Removed creation of the `GSI-ROLE` global secondary index from the DynamoDB member table in both the infrastructure-as-code (`iac/dynamo_stack.py`) and local table setup scripts (`load_member_mock_to_dynamo.py`). Attribute definitions for `GSI-ROLE-PK` and `GSI-ROLE-SK` were also removed. [[1]](diffhunk://#diff-72e2e9e5efcc634e94fdc57f910324a5c9de18c480e5f58d9dfe25ff6f546933L98-L109) [[2]](diffhunk://#diff-6cad25e321eff38698d59e9cdf5e0753b3b581b7529bee037819092f61607293L28-L46) [[3]](diffhunk://#diff-6cad25e321eff38698d59e9cdf5e0753b3b581b7529bee037819092f61607293L55-L62)

**Environment Configuration Cleanup**
* Removed environment variables and static assignments for `dynamo_gsi_member_partition_key` and `dynamo_gsi_member_sort_key` from the environment loader, as these are no longer needed. [[1]](diffhunk://#diff-6fa257a386e343616f5b7f8f90ff9faa309d4585ec92acb37bc4bd1240125176L60-L61) [[2]](diffhunk://#diff-6fa257a386e343616f5b7f8f90ff9faa309d4585ec92acb37bc4bd1240125176L87-L88)

**Repository Logic Refactor**
* Refactored the member repository to remove GSI-related key formatting methods and parameters. Member creation and update logic no longer sets GSI attributes. Queries for active heads and directors now use a scan with attribute filters instead of GSI queries. [[1]](diffhunk://#diff-11cc4c378fdbb6493153598bffc8d8ba397f27517397da6a4384f3f5fb6d62f1L33-R39) [[2]](diffhunk://#diff-11cc4c378fdbb6493153598bffc8d8ba397f27517397da6a4384f3f5fb6d62f1L69-L71) [[3]](diffhunk://#diff-11cc4c378fdbb6493153598bffc8d8ba397f27517397da6a4384f3f5fb6d62f1L100-R101) [[4]](diffhunk://#diff-11cc4c378fdbb6493153598bffc8d8ba397f27517397da6a4384f3f5fb6d62f1L183-L184) [[5]](diffhunk://#diff-11cc4c378fdbb6493153598bffc8d8ba397f27517397da6a4384f3f5fb6d62f1R22)

**Test Updates**
* Updated the test for `get_active_heads_and_directors` to reflect the switch from GSI query to scan with filter, including renaming and adjusting test comments.…h in the db with an scan and also removed the gsi-role in member's table